### PR TITLE
[pre sync PR] Make SmartyCompilerException play nicer with error hand…

### DIFF
--- a/libs/sysplugins/smarty_internal_templatecompilerbase.php
+++ b/libs/sysplugins/smarty_internal_templatecompilerbase.php
@@ -1131,12 +1131,12 @@ abstract class Smarty_Internal_TemplateCompilerBase
             echo ob_get_clean();
             flush();
         }
-        $e = new SmartyCompilerException($error_text);
-        $e->setLine($line);
-        $e->source = trim(preg_replace('![\t\r\n]+!', ' ', $match[ $line - 1 ]));
-        $e->desc = $args;
-        $e->template = $this->template->source->filepath;
-        throw $e;
+        throw new SmartyCompilerException(
+            $error_text,
+            0,
+            $this->template->source->filepath,
+            $line
+        );
     }
 
     /**

--- a/libs/sysplugins/smartycompilerexception.php
+++ b/libs/sysplugins/smartycompilerexception.php
@@ -8,39 +8,37 @@
 class SmartyCompilerException extends SmartyException
 {
     /**
+     * The constructor of the exception
+     *
+     * @param string         $message  The Exception message to throw.
+     * @param int            $code     The Exception code.
+     * @param string|null    $filename The filename where the exception is thrown.
+     * @param int|null       $line     The line number where the exception is thrown.
+     * @param Throwable|null $previous The previous exception used for the exception chaining.
+     */
+    public function __construct(
+        string $message = "",
+        int $code = 0,
+        ?string $filename = null,
+        ?int $line = null,
+        Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+
+        // These are optional parameters, should be be overridden only when present!
+        if ($filename) {
+            $this->file = $filename;
+        }
+        if ($line) {
+            $this->line = $line;
+        }
+    }
+
+    /**
      * @return string
      */
     public function __toString()
     {
         return ' --> Smarty Compiler: ' . $this->message . ' <-- ';
     }
-
-    /**
-     * @param int $line
-     */
-    public function setLine($line)
-    {
-        $this->line = $line;
-    }
-
-    /**
-     * The template source snippet relating to the error
-     *
-     * @type string|null
-     */
-    public $source = null;
-
-    /**
-     * The raw text of the error message
-     *
-     * @type string|null
-     */
-    public $desc = null;
-
-    /**
-     * The resource identifier or template name
-     *
-     * @type string|null
-     */
-    public $template = null;
 }


### PR DESCRIPTION
…ler libraries

to avoid "PHP Fatal error:  Type of SmartyCompilerException::$line must be int (as in class Exception) in .../libs/sysplugins/smartycompilerexception.php on line 8"
without any valuable passthrough message.