### PR TITLE
82fixups

### DIFF
--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -147,11 +147,6 @@ class Smarty extends Smarty_Internal_TemplateBase
     const PLUGIN_MODIFIERCOMPILER = 'modifiercompiler';
 
     /**
-     * Declare $smarty property for PHP 8.2 deprecation of dynamic properties
-     */
-    public $smarty = null;
-
-    /**
      * assigned global tpl vars
      */
     public static $global_tpl_vars = array();

--- a/libs/sysplugins/smarty_internal_extension_handler.php
+++ b/libs/sysplugins/smarty_internal_extension_handler.php
@@ -67,7 +67,7 @@ class Smarty_Internal_Extension_Handler
     public function _callExternalMethod(Smarty_Internal_Data $data, $name, $args)
     {
         /* @var Smarty $data ->smarty */
-        $smarty = $data->smarty ?? $data;
+        $smarty = isset($data->smarty) ? $data->smarty : $data; // don't use ?? for isset here since that would need a follow-up property define in Smarty class for __get()
         if (!isset($smarty->ext->$name)) {
             if (preg_match('/^((set|get)|(.*?))([A-Z].*)$/', $name, $match)) {
                 $basename = $this->upperCase($match[ 4 ]);


### PR DESCRIPTION
Improve particulary ternary conversion for missing property issue on Smarty origin PR merge.
Now this is usable without adding the $marty property define for the magic __get method.